### PR TITLE
Fix data path in message, improve formatting

### DIFF
--- a/ioquake3
+++ b/ioquake3
@@ -5,16 +5,16 @@
 
 function error-message {
     cat << EOM
-ioquake3 needs the official Quake 3 .pk3-files to function
-properly (specifically baseq3/pak0.pk3 … baseq3/pak8.pk3 and
-optionally also missionpack/pak0.pk3 … missionpack/pak3.pk3).
+ioquake3 needs the official Quake 3 .pk3-files to function properly
+(specifically baseq3/pak0.pk3 … baseq3/pak8.pk3 and optionally
+also missionpack/pak0.pk3 … missionpack/pak3.pk3).
 
-One way to obtain these files is to buy Quake 3 Arena on
-Steam, and extract the files from the installation directory.
+One way to obtain these files is to buy Quake 3 Arena on Steam,
+and extract the files from the installation directory.
 
 Once you've obtained the files, copy them to:
 
-    ~/.var/app/org.ioquake3.IOQuake3/data/baseq3/
+    ~/.var/app/org.ioquake3.IOQuake3/data/
 
 … and restart ioquake3
 EOM
@@ -28,7 +28,7 @@ mkdir -p "${XDG_DATA_HOME}"/{baseq3,missionpack}
 for i in $(seq 0 8); do
     if [ ! -f "${XDG_DATA_HOME}/baseq3/pak${i}.pk3" ]; then
         zenity --error      \
-               --width=400  \
+               --width=450  \
                --height=200 \
                --text="$(error-message)"
         exit 2


### PR DESCRIPTION
The baseq3 dir is only used for base Q3A files, not missionpack and other additional pk3s.

Also, the current text formatting in the Zenity dialog does not look ideal:

![formatting](https://github.com/mattiasb/flathub/assets/2339930/16ae5b0e-30aa-48d8-a833-17e497fcb3a7)

This PR changes the formatting and slightly increases the Zenity window width to make it look much better:

![formatting_after](https://github.com/mattiasb/flathub/assets/2339930/690c3547-d7cf-4fc7-9f61-a644c71848c9)