### PR TITLE
Rename the Flatpak, fix AppStream metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# org.ioquake3.IOQuake3
+# org.ioquake3.ioquake3
 
 Flatpak recipe for <http://ioquake3.org>.
 
 ## Install
 
 ```shell
-$ flatpak-builder build --install --user ./org.ioquake3.IOQuake3.yaml
+$ flatpak-builder build --install --user ./org.ioquake3.ioquake3.yaml
 ```
 
 ## Flathub?

--- a/ioquake3
+++ b/ioquake3
@@ -13,7 +13,7 @@ Steam, and extract the files from the installation directory.
 
 Once you've obtained the files, copy them to:
 
-    ~/.var/app/org.ioquake3.IOQuake3/data/baseq3/
+    ~/.var/app/org.ioquake3.ioquake3/data/baseq3/
 
 … and restart ioquake3
 EOM

--- a/org.ioquake3.ioquake3.metainfo.xml
+++ b/org.ioquake3.ioquake3.metainfo.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>org.ioquake3.IOQuake3</id>
-  <launchable type="desktop-id">org.ioquake3.IOQuake3.desktop</launchable>
+  <id>org.ioquake3.ioquake3</id>
+  <launchable type="desktop-id">org.ioquake3.ioquake3.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <provides>
     <id>ioquake3.desktop</id>
   </provides>
@@ -36,13 +36,15 @@
       </image>
     </screenshot>
   </screenshots>
+  <url type="vcs-browser">https://github.com/ioquake/ioq3</url>
   <developer_name>The ioquake Group</developer_name>
   <releases>
     <release version="1.36_GIT" date="2023-07-06"/>
   </releases>
   <content_rating type="oars-1.1">
-    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-realistic">intense</content_attribute>
     <content_attribute id="violence-bloodshed">intense</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
   </content_rating>
 </component>

--- a/org.ioquake3.ioquake3.metainfo.xml
+++ b/org.ioquake3.ioquake3.metainfo.xml
@@ -39,7 +39,7 @@
   <url type="vcs-browser">https://github.com/ioquake/ioq3</url>
   <developer_name>The ioquake Group</developer_name>
   <releases>
-    <release version="1.36_GIT" date="2023-07-06"/>
+    <release version="1.36_GIT" date="2023-08-19"/>
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-realistic">intense</content_attribute>

--- a/org.ioquake3.ioquake3.yaml
+++ b/org.ioquake3.ioquake3.yaml
@@ -41,7 +41,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/ioquake/ioq3.git
-        commit: 10a45cbdc131a35530d89bd3cfc2a7eed74b54cc
+        commit: b1e6ef14254fdcb77cbe2f602c22549d3fb0eb78
 
   - name: ioquake3-launcher
     buildsystem: simple

--- a/org.ioquake3.ioquake3.yaml
+++ b/org.ioquake3.ioquake3.yaml
@@ -1,5 +1,5 @@
 ---
-app-id: org.ioquake3.IOQuake3
+app-id: org.ioquake3.ioquake3
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
@@ -49,7 +49,7 @@ modules:
       - install -Dm 744 ioquake3 -t /app/bin
     sources:
       # ioquake3 launcher script that:
-      # - … makes ~/.q3a/ available at ~/.var/app/org.ioquake3.IOQuake3/data/
+      # - … makes ~/.q3a/ available at ~/.var/app/org.ioquake3.ioquake3/data/
       # - … explains (via zenity) where the user can put configs and pk3-files.
       - type: file
         path: ioquake3
@@ -57,8 +57,8 @@ modules:
   - name: ioquake3-metainfo
     buildsystem: simple
     build-commands:
-      - install -Dm 644 org.ioquake3.IOQuake3.metainfo.xml
+      - install -Dm 644 org.ioquake3.ioquake3.metainfo.xml
                 -t /app/share/metainfo
     sources:
       - type: file
-        path: org.ioquake3.IOQuake3.metainfo.xml
+        path: org.ioquake3.ioquake3.metainfo.xml


### PR DESCRIPTION
See the following upstream commits:

https://github.com/ioquake/ioq3/commit/e5c688b342b8e7edd88bc670c02c9050e007fcab
https://github.com/ioquake/ioq3/commit/b1e6ef14254fdcb77cbe2f602c22549d3fb0eb78

(Screenshots are not a problem for downstream/Flatpak, so no need to remove or change them.)

@mattiasb Feel free to review.